### PR TITLE
Fix goroutine leak in socket.sender

### DIFF
--- a/protocol/xpush/xpush.go
+++ b/protocol/xpush/xpush.go
@@ -261,6 +261,7 @@ func (s *socket) Close() error {
 		return protocol.ErrClosed
 	}
 	s.closed = true
+	s.cv.Signal()
 	s.Unlock()
 	close(s.closeQ)
 	return nil


### PR DESCRIPTION
When socket.sender is waiting to send a message to a socket that has been closed, it will wait indefinitely on s.cv.Wait().  This change sends a signal to notify the s.cv.wait called in socket.sender that the socket has been closed.